### PR TITLE
Fix paths on macos/linux

### DIFF
--- a/src/worker/Worker.js
+++ b/src/worker/Worker.js
@@ -6,7 +6,7 @@ function Worker (queue, callbackExit) {
   this.queue = queue;
 
   /* Internal worker thread */
-  const _worker = new workerThreads.Worker(`${__dirname}\\workerThreadExecutor.js`);
+  const _worker = new workerThreads.Worker(`${__dirname}/workerThreadExecutor.js`);
   this.busy = false;
   this.callback = null;
 


### PR DESCRIPTION
Fix paths on macos/linux

proj/node_modules/node-workers-pool/src/worker**\**workerThreadExecutor.js
proj/node_modules/node-workers-pool/src/worker**/**workerThreadExecutor.js